### PR TITLE
added a migration to add a suppressed column to the authorizer rlshp table

### DIFF
--- a/migrations/003_add_suppressed_to_authorizer_rlshp.rb
+++ b/migrations/003_add_suppressed_to_authorizer_rlshp.rb
@@ -1,0 +1,14 @@
+Sequel.migration do
+
+  up do
+    alter_table(:payment_authorizer_rlshp) do
+      add_column(:suppressed, :integer, :null => false, :default => 0)
+    end
+  end
+
+
+  down do
+    # nothing
+  end
+
+end


### PR DESCRIPTION
This fixes 82480716:
    As an Archivist, I want to be able to save accession records that include payments
    with an associated authorizor when I have edit permissions but not admin.

It seems the relationship code expects a :suppressed column on rlshp tables. This just adds one to payment_authorizer_rlshp, which seems to make the problem go away.

It is only indirectly a permissions problem - the call to relationship.suppressed is only reached if suppression is being enforced (ie the user doesn't have the permission to see suppressed records). This explains why the bug isn't exercised when logged in as admin.
